### PR TITLE
Swap build key for pre-existing image key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.5'
 services:
   okbr-serenata-notebooks:
     container_name: okbr-serenata-notebooks
-    build: .
+    image: okbr/serenata-notebooks
     networks:
       - frontend
     ports:


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
This PR updates `docker-compose.yml` to pull the pre-built image on Docker Hub instead of building the image locally.

**What was done to achieve this purpose?**
I removed the `build: .` command on line 7 and replaced it with the existing Docker Hub image key.


**How to test if it really works?**
By following the instructions here: [To Run Jupyter using Docker Compose](https://github.com/okfn-brasil/notebooks/blob/master/getting-started.md#to-run-jupyter-using-docker-compose)

**Who can help reviewing it?**
@jtemporal 

**TODO**

_Here goes the todo list with some missing step to complete it_